### PR TITLE
Add aws_instance_profile option for Roles

### DIFF
--- a/examples/roles/README.md
+++ b/examples/roles/README.md
@@ -24,14 +24,15 @@ The following defined role has administrator access on the provisioned AWS accou
 ```hcl
 roles = [
   {
-    name                 = "ROLE-ADMIN"
-    path                 = null
-    desc                 = null
-    trust_policy_file    = "data/trust-policies/admin.json"
-    permissions_boundary = null
-    policies             = []
-    inline_policies      = []
-    policy_arns          = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+    name                    = "ROLE-ADMIN"
+    path                    = null
+    desc                    = null
+    trust_policy_file       = "data/trust-policies/admin.json"
+    permissions_boundary    = null
+    policies                = []
+    inline_policies         = []
+    policy_arns             = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+    create_instance_profile = false
   },
 ]
 ```

--- a/main.tf
+++ b/main.tf
@@ -248,6 +248,13 @@ resource "aws_iam_role" "roles" {
   )
 }
 
+resource "aws_iam_instance_profile" "test_profile" {
+  for_each = { for role in var.roles : role.name => role if role.create_instance_profile == true  }
+  name = lookup(each.value, "name")
+  path = lookup(each.value, "path", null) == null ? var.role_path : lookup(each.value, "path")
+  role = aws_iam_role.roles[each.value.name].name
+}
+
 # Attach customer managed policies to roles
 resource "aws_iam_role_policy_attachment" "policy_attachments" {
   for_each = local.role_policies

--- a/variables.tf
+++ b/variables.tf
@@ -251,6 +251,7 @@ variable "roles" {
       file = string      # Path to json or json.tmpl file of policy
       vars = map(string) # Policy template variables {key = val, ...}
     }))
+    create_instance_profile = bool
   }))
   default = []
 }


### PR DESCRIPTION
AWS Instance Profiles must be created if this role is going to be assumed by something like a Launch Configuration.
